### PR TITLE
Improve checking of ASF endpoint if SLC is available for download

### DIFF
--- a/acquisition_localizer_single.py
+++ b/acquisition_localizer_single.py
@@ -245,11 +245,12 @@ def resolve_s1_slc(identifier, download_url, asf_queue, esa_queue):
     #asf_queue = "spyddder-sling-extract-asf"
     #esa_queue = "spyddder-sling-extract-scihub"
 
-    # determine best url and corresponding queue
+    # determine best url and corresponding queue by getting first 100 bytes
     vertex_url = "https://datapool.asf.alaska.edu/SLC/SA/{}.zip".format(identifier)
-    r = requests.head(vertex_url, allow_redirects=True)
+    headers = {"Range": "bytes=0-100"}
+    r = requests.head(vertex_url, allow_redirects=True, headers=headers)
     logger.info("Status Code from ASF : %s" %r.status_code)
-    if asf_queue.upper() != "NA" and r.status_code in (200, 403):
+    if asf_queue.upper() != "NA" and r.status_code in (200, 206):
         url = r.url
         queue = asf_queue
         url_type = "asf"

--- a/acquisition_localizer_single.py
+++ b/acquisition_localizer_single.py
@@ -248,7 +248,7 @@ def resolve_s1_slc(identifier, download_url, asf_queue, esa_queue):
     # determine best url and corresponding queue by getting first 100 bytes
     vertex_url = "https://datapool.asf.alaska.edu/SLC/SA/{}.zip".format(identifier)
     headers = {"Range": "bytes=0-100"}
-    r = requests.head(vertex_url, allow_redirects=True, headers=headers)
+    r = requests.get(vertex_url, allow_redirects=True, headers=headers)
     logger.info("Status Code from ASF : %s" %r.status_code)
     if asf_queue.upper() != "NA" and r.status_code in (200, 206):
         url = r.url


### PR DESCRIPTION
I realized that maybe due to the latest changes in authentication via the ASF endpoint, the current method always returns r.status_code of 403 with `requests.head()` regardless if the SLC is in ASF or not. With this issue,  it will still submit an SLC not in ASF endpoint to `sling-extract-asf` regardless even when the SLC is not in ASF. (refer to logs at very bottom)

E.g.:
```
S1A_IW_SLC__1SDV_20200415T042433_20200415T042503_032133_03B6EE_CAF1 is NOT IN ASF:
>>> 
requests.head("https://datapool.asf.alaska.edu/SLC/SA/S1A_IW_SLC__1SDV_20200415T042433_20200415T042503_032133_03B6EE_CAF1.zip", allow_redirects=True)
<Response [403]>

S1A_IW_SLC__1SDV_20190831T223325_20190831T223353_028819_0343DC_B3A8 is IN ASF:
>>> requests.head("https://datapool.asf.alaska.edu/SLC/SA/S1A_IW_SLC__1SDV_20190831T223325_20190831T223353_028819_0343DC_B3A8.zip", allow_redirects=True)
<Response [403]>
```

Based on https://aria.atlassian.net/projects/ARIA/issues/ARIA-71?filter=allopenissues&orderby=priority%20DESC, `requests.get()` is recommended instead of `requests.head()`
 * Added a header to get the first 100 bytes only, so we do not read entire SLC data while attempting the GET. This saves more time if the SLC is actually there.

E.g Tests on this method:
```
IF SLC IS NOT IN ASF
>>> headers = {"Range": "bytes=0-100"}
>>>re.get("https://datapool.asf.alaska.edu/SLC/SA/S1A_IW_SLC__1SDV_20200415T231528_20200415T231555_032144_03B756_C673.zip", allow_redirects=True, headers=headers) 
<Response [404]>

IF SLC IS IN ASF:
>>> headers = {"Range": "bytes=0-100"}
>>> re.get("https://datapool.asf.alaska.edu/SLC/SA/S1A_IW_SLC__1SDV_20191221T215749_20191221T215816_030452_037C5D_DCDA.zip", allow_redirects=True, headers=headers) 
<Response [206]>
```



* Logs and ASF query using an SLC ID not in ASF:
[before implementation](https://gist.github.com/shitong01/485add7ff15c43ea009c5b07c8cc6a18)
[after implementation](https://gist.github.com/shitong01/d17a36ebdb599887d879fc587f2dab1a)